### PR TITLE
Add support for direct responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,11 @@ slack.send('chat.postMessage', message).then(data => {
 // respond to webhooks
 slack.send('https://hooks.slack.com/services/T0000/B000/XXXX', message);
 ```
+You can also respond to events directly without an API call using the callback method. This is useful if you need the `in_channel` response type to show the users slash command too.
+```js
+// Example for a command that takes a name eg: /greet Bob
+slack.on('/greet', msg => slack.callback({ 
+  response_type: 'in_channel', 
+  text: `Hey there ${msg.text}!`
+}))
+```

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,6 @@ class Slack extends EventEmitter {
    * @param {Object} response A response object or string
    */
   callback(callback, response) {
-    delete this.callback;
     callback(null, JSON.stringify(response));
   }
 
@@ -136,10 +135,6 @@ class Slack extends EventEmitter {
 
     // trigger all events
     events.forEach(name => this.emit(name, payload, bot, this.store));
-        
-    // Send success signal if callback not used in handler
-    if ( this.callback )
-      this.callback();
   }
 
 }


### PR DESCRIPTION
Sometimes in the case of slash commands it's useful to have the users command displayed too - it helps to educate / show other users how to use a command they may not have seen before.

It can also add context to a response rather than the response having to indicate what just happened when it's visible to all users.