### PR TITLE
Handle "ok" response.data value

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -141,7 +141,7 @@ class Client {
   getData(response) {
     let data = response.data;
 
-    if (data.ok) {
+    if (data.ok || data === 'ok') {
       delete data.ok;
       return Promise.resolve(data);
     } else {


### PR DESCRIPTION
If we're using `response_url` as an endpoint, `response.data` will only contain "ok" string value.