### PR TITLE
Remove duplicate interactive message processing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ class Slack extends EventEmitter {
     if (payload.trigger_word) events.push('webhook', payload.trigger_word);
 
     // notify message button triggered by callback_id
-    if (payload.callback_id) events.push('interactive_message', payload.callback_id);
+    if (payload.callback_id) events.push(payload.callback_id);
 
     // trigger all events
     events.forEach(name => this.emit(name, payload, bot, this.store));


### PR DESCRIPTION
Interactive message payloads include the type field so they are already
staged for execution in the payload.type if statement.