### PR TITLE
Fix: Validating if table name variable exists and renaming it

### DIFF
--- a/src/dynamo.js
+++ b/src/dynamo.js
@@ -37,7 +37,9 @@ exports.get = function(id) {
  * @return {Promise} A Promise with the get result
  */
 exports.query = function(method, params) {
-  params.TableName = process.env.TABLE_NAME;
+  process.env.SERVERLESS_SLACK_OAUTH_TABLE
+    ? params.TableName = process.env.SERVERLESS_SLACK_OAUTH_TABLE
+    : params.TableName = 'serverless-slack-oauth-table';
 
   return new Promise((resolve, reject) => {
     dynamo[method](params, (err, data) => {

--- a/src/dynamo.js
+++ b/src/dynamo.js
@@ -37,9 +37,7 @@ exports.get = function(id) {
  * @return {Promise} A Promise with the get result
  */
 exports.query = function(method, params) {
-  process.env.SERVERLESS_SLACK_OAUTH_TABLE
-    ? params.TableName = process.env.SERVERLESS_SLACK_OAUTH_TABLE
-    : params.TableName = 'serverless-slack-oauth-table';
+  params.TableName = process.env.TABLE_NAME || 'serverless-slack-oauth-table';
 
   return new Promise((resolve, reject) => {
     dynamo[method](params, (err, data) => {


### PR DESCRIPTION
Fixes #14 

Adding validation to check if ```TABLE_NAME``` exists or not. On this way, the app will not crash.