### PR TITLE
Create New Client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 John Agan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-slack",
   "description": "A Slack App Framework for AWS Lambda / Serverless.js",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "main": "src/index.js",
   "author": "John Agan <john@slack-corp.com>",
   "homepage": "https://github.com/johnagan/serverless-slack",

--- a/src/index.js
+++ b/src/index.js
@@ -127,6 +127,12 @@ class Slack extends EventEmitter {
     events.forEach(name => this.emit(name, payload, bot, this.store));
   }
 
+  /**
+   * Create new slack client to be used with customBot
+  */
+  client() {
+    return new Client({}, {});
+  }  
 }
 
 module.exports = new Slack();


### PR DESCRIPTION
This PR has added a function that creates a new slack client so `customBot` can be instantiated and used in the `Ketchup Slack App`.